### PR TITLE
feat: config.after_initialize instead of config.to_prepare

### DIFF
--- a/lib/active_dry_deps/railtie.rb
+++ b/lib/active_dry_deps/railtie.rb
@@ -3,7 +3,7 @@
 module ActiveDryDeps
   class Railtie < ::Rails::Railtie
 
-    config.to_prepare do
+    config.after_initialize do
       Object.const_set(ActiveDryDeps.config.inject_global_constant, ::ActiveDryDeps::Deps)
       ActiveDryDeps.config.finalize!(freeze_values: true)
     end


### PR DESCRIPTION
Fixes reinitialization of `Deps` constant in tests

```sh
❯ rspec spec/slices/markets/yandexmarket/services/upload_offers_to_market_spec.rb:260
/Users/michaelkhabarov/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/active_dry_deps-73c229249e1d/lib/active_dry_deps/railtie.rb:7: warning: already initialized constant Deps
/Users/michaelkhabarov/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/active_dry_deps-73c229249e1d/lib/active_dry_deps/railtie.rb:7: warning: previous definition of Deps was here
/Users/michaelkhabarov/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/active_dry_deps-73c229249e1d/lib/active_dry_deps/railtie.rb:7: warning: already initialized constant Deps
/Users/michaelkhabarov/.local/share/mise/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/active_dry_deps-73c229249e1d/lib/active_dry_deps/railtie.rb:7: warning: previous definition of Deps was here
```