### PR TITLE
remove ActiveDryDeps.config.inject_global_constant before set

### DIFF
--- a/lib/active_dry_deps/railtie.rb
+++ b/lib/active_dry_deps/railtie.rb
@@ -3,8 +3,11 @@
 module ActiveDryDeps
   class Railtie < ::Rails::Railtie
 
-    config.after_initialize do
-      Object.const_set(ActiveDryDeps.config.inject_global_constant, ::ActiveDryDeps::Deps)
+    config.to_prepare do
+      const_name = ActiveDryDeps.config.inject_global_constant
+      Object.send(:remove_const, const_name) if Object.const_defined?(const_name)
+      Object.const_set(const_name, ::ActiveDryDeps::Deps)
+
       ActiveDryDeps.config.finalize!(freeze_values: true)
     end
 


### PR DESCRIPTION
По сути реверт этого pr https://github.com/corp-gp/active_dry_deps/pull/7 плюс удаляю константу, если установлена, чтобы не было варнинга в тестах

В проде `after_initialize` поздно вызывается